### PR TITLE
Preemptor lost in preemption action

### DIFF
--- a/pkg/scheduler/actions/preempt/preempt.go
+++ b/pkg/scheduler/actions/preempt/preempt.go
@@ -134,6 +134,11 @@ func (alloc *preemptAction) Execute(ssn *framework.Session) {
 
 		// Preemption between Task within Job.
 		for _, job := range underRequest {
+			// Fix: missing preemptor numbers when in same job
+			preemptorTasks[job.UID] = util.NewPriorityQueue(ssn.TaskOrderFn)
+			for _, task := range job.TaskStatusIndex[api.Pending] {
+				preemptorTasks[job.UID].Push(task)
+			}
 			for {
 				if _, found := preemptorTasks[job.UID]; !found {
 					break

--- a/pkg/scheduler/plugins/priority/priority.go
+++ b/pkg/scheduler/plugins/priority/priority.go
@@ -84,12 +84,20 @@ func (pp *priorityPlugin) OnSessionOpen(ssn *framework.Session) {
 		var victims []*api.TaskInfo
 		for _, preemptee := range preemptees {
 			preempteeJob := ssn.Jobs[preemptee.Job]
-			if preempteeJob.Priority >= preemptorJob.Priority {
-				glog.V(4).Infof("Can not preempt task <%v/%v> because "+
-					"preemptee has greater or equal job priority (%d) than preemptor (%d)",
-					preemptee.Namespace, preemptee.Name, preempteeJob.Priority, preemptorJob.Priority)
-			} else {
-				victims = append(victims, preemptee)
+			if preempteeJob.UID != preemptorJob.UID {
+				if preempteeJob.Priority >= preemptorJob.Priority {
+					glog.V(4).Infof("Can not preempt task <%v/%v> because preemptee job has greater or equal job priority (%d) than preemptor (%d)",
+						preemptee.Namespace, preemptee.Name, preempteeJob.Priority, preemptorJob.Priority)
+				} else {
+					victims = append(victims, preemptee)
+				}
+			} else { // same job's diffenrent tasks should compare task's priority
+				if preemptee.Priority >= preemptor.Priority {
+					glog.V(4).Infof("Can not preempt task <%v/%v> because preemptee task has greater or equal task priority (%d) than preemptor (%d)",
+						preemptee.Namespace, preemptee.Name, preemptee.Priority, preemptor.Priority)
+				} else {
+					victims = append(victims, preemptee)
+				}
 			}
 		}
 

--- a/pkg/scheduler/util/test_utils.go
+++ b/pkg/scheduler/util/test_utils.go
@@ -48,6 +48,13 @@ func BuildResourceListWithGPU(cpu string, memory string, GPU string) v1.Resource
 	}
 }
 
+// BuildResourceListWithPods builts resource list with PODs
+func BuildResourceListWithPods(cpu, memory string, pods string) v1.ResourceList {
+	r := BuildResourceList(cpu, memory)
+	r[v1.ResourcePods] = resource.MustParse(pods)
+	return r
+}
+
 // BuildNode builts node object
 func BuildNode(name string, alloc v1.ResourceList, labels map[string]string) *v1.Node {
 	return &v1.Node{
@@ -89,6 +96,13 @@ func BuildPod(namespace, name, nodename string, p v1.PodPhase, req v1.ResourceLi
 			},
 		},
 	}
+}
+
+// BuildPodWithPrio build pod with a priority
+func BuildPodWithPrio(namespace, name, nodename string, p v1.PodPhase, req v1.ResourceList, groupName string, prio *int32, labels map[string]string, selector map[string]string) *v1.Pod {
+	pod := BuildPod(namespace, name, nodename, p, req, groupName, labels, selector)
+	pod.Spec.Priority = prio
+	return pod
 }
 
 // FakeBinder is used as fake binder


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Fix issue #950 
In preemption action, it wil first try to preempt from other jobs and will pop preemptor from preemptorTasks queue which is used to record the preeptor tasks. This cause preemptorTasks miss one preemptor task at least when There is no other jobs can be preempted and try to preempt other tasks in the same job

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #950
when preempt task between same job's tasks, it should compare task's priority in this job;

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

